### PR TITLE
External API added...

### DIFF
--- a/difference_engine.py
+++ b/difference_engine.py
@@ -271,6 +271,139 @@ def compliance_run(directory, data, report_files, json_files):
     pdf_filename = pdf_converter(pdf_data, report_path)
     return pdf_filename
 
+# This function will compare multiple rules against one config passed to it in API
+def external_audit(cfg, data):
+    """
+    we will use the audit dictionary created to compare 
+    against the configuration presented to determine if the
+    configuration has violations
+    :param cfg: configuration file path and filename
+    :param audit_dict: imported dictionary of audit rules
+    :return: text with config lines that violated in a dictionary
+    """
+
+    # create a diff_list that will include all the lines that are non compliant
+    violation_list = []
+    violation_output = ''
+    for i in range(0, (len(data)-1)):
+        instance = []
+        instance_output = []
+        if isinstance(data[i], list):
+            config_section = []
+            output = False
+            for sub_dict in data[i]:
+                scope = (sub_dict['Scope'])
+                operator = (sub_dict['Operator'])
+                value = (sub_dict['Value'])
+                if value.startswith("*"):
+                    value = "." + value[1:]
+                elif value.startswith("^*"):
+                    value = "^." + value[2:]
+                if "(.*)" in value:
+                    value = value.replace('(.*)', '.*')
+                message = (sub_dict['Message'])
+                regex = re.compile(value)
+                if scope == "SUBMODE_CONFIG":
+                    config_section = show_run_section(cfg, regex)
+                    config_subsections = show_run_section_array(config_section)
+                    #print("\nTest: "+str(i)+"\nsection: ",config_section,"\nsubsection: ",config_subsections)
+                    #print("\n\nsearch: ",regex)
+                    if config_section != "":
+                        output = True
+                        carryonflag = True
+                    else:
+                        output = True
+                        carryonflag = False
+                    #print("\n\n",output,carryonflag)
+                elif ((scope == "PREVIOUS_SUBMODE_CONFIG") and (len(config_section)!=0)):
+                    for subsection in config_subsections:
+                        #print(subsection)
+                        if regex.search(subsection):
+                            if operator == "MATCHES_EXPRESSION" or operator == "CONTAINS":
+                                output = True
+                                carryonflag == True
+                                #print("1")
+                            elif operator == "DOES_NOT_MATCH":
+                                output = False
+                                carryonflag = False
+                                #print("2")
+                                #print(regex.search(subsection))
+                                #print(subsection)
+                                instance.append(regex.search(subsection))
+                                instance_output.append(subsection)
+                        else:
+                            if operator == "MATCHES_EXPRESSION" or operator == "CONTAINS":
+                                output = False
+                                carryonflag = False
+                                #print("3")
+                                #print(regex.search(subsection))
+                                #print(subsection)
+                                instance.append(regex.search(subsection))
+                                instance_output.append(subsection)
+                            elif operator == "DOES_NOT_MATCH":
+                                output = True
+                                carryonflag == True
+                                #print("4")
+                    #print(output,carryonflag)
+            if output == True:
+                violation_output = "test "+str(i)+": >> Passed"
+            elif output == False:
+                #violation_output = "test "+str(i)+": >> search: '"+value+"' >> Violation Msg: "+message
+                violation_output = "test "+str(i)+": >> Violation Msg: "+message
+                if (len(instance)>0):
+                    violation_output = violation_output + "\n\nInstances:"
+                    if (len(instance)>1):
+                        for n in range(0,len(instance)-1):
+                            if str(instance[n]) != "None":
+                                #violation_output = violation_output + "\n" + str(instance[n])
+                                violation_output = violation_output + "\n" + str(instance_output[n])
+                    else:
+                        if str(instance):
+                            #violation_output = violation_output + "\n" + str(instance)
+                            violation_output = violation_output + "\n" + str(instance_output[0])
+                    violation_output = violation_output + "\n"
+            violation_list.append(violation_output)
+        if isinstance(data[i], dict):
+            output = True
+            scope = data[i]['Scope']
+            operator = data[i]['Operator']
+            value = data[i]['Value']
+            if value.startswith("*"):
+                value = "." + value[1:]
+            elif value.startswith("^*"):
+                value = "^." + value[2:]
+            if "(.*)" in value:
+                value = value.replace('(.*)', '.*')
+            regex = re.compile(value)
+            message = data[i]['Message']
+            # for loop for a match in all_config
+            for line in cfg:
+                if regex.search(line):
+                    if operator == "MATCHES_EXPRESSION" or operator == "CONTAINS":
+                        output = True
+                        break
+                    else:
+                        output = False
+                elif value in line:
+                    if operator == "MATCHES_EXPRESSION" or operator == "CONTAINS":
+                        output = True
+                        break
+                    else:
+                        output = False
+                else:
+                    if operator == "MATCHES_EXPRESSION" or operator == "CONTAINS":
+                        output = False
+                    else:
+                        output = True
+                        break                    
+            if output == True:
+                violation_output = "test "+str(i)+": >> Passed"
+            elif output == False:
+                #violation_output = "test "+str(i)+": >> search: '"+value+"' >> Violation Msg: "+message
+                violation_output = "test "+str(i)+": >> Violation Msg: "+message
+            violation_list.append(violation_output)
+    return violation_list
+
 #     ----------------------------- MAIN -----------------------------
 
 # code below for development purposes and testing only

--- a/prime_compliance_dictionary.py
+++ b/prime_compliance_dictionary.py
@@ -117,7 +117,23 @@ def all_files_into_dict(DIRECTORY):
                 counter = counter + 1
     return audit_database
 
-#deal with array of conditions next
+# Read XML file into a dictionary
+def xml_str_into_dict(xml_str):
+    audit_database = {}
+    counter = 0
+    # parse the all the xml files
+    comp_rule = xmltodict.parse(xml_str)
+    #print("\n\n",comp_rule)
+    if type(comp_rule['CustomPolicy']['Rules']['Rule']['Conditions']['Condition']) != list :
+        #audit_rule = dictionary_builder_single(comp_rule, counter)
+        #print("\n\n",audit_rule)
+        audit_database.update(dictionary(comp_rule, counter))
+        #print("\n\n",audit_database)
+        counter = counter + 1
+    else:
+        audit_database.update(dictionary_list(comp_rule, counter))
+        counter = counter + 1
+    return audit_database
 
 #     ----------------------------- MAIN -----------------------------
 


### PR DESCRIPTION
Please expose the following API in the Swagger-UI

1. difference-engine.external_audit(cfg, data)

This API takes a data-set of audit rules previously created by another call [xml_str_into_dict} and a config in array format and returns the violations in an array.

[cfg] =  configuration in array format
[data] = data-set of audit rules

2. difference-engine.xml_str_into_dict(xml_str):

This API takes an xml string passed to it and returns a dictionary to be used by [external_audit]

[xml_str] = xml data read previously and parsed as a string to the function to return a dictionary for auditing.